### PR TITLE
Apply AnnotatedRegion that fixes #51

### DIFF
--- a/app/lib/pages/home_page.dart
+++ b/app/lib/pages/home_page.dart
@@ -1,5 +1,6 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 
 import '../models/post.dart';
@@ -7,6 +8,7 @@ import '../models/post_mock.dart';
 import '../posts_list.dart';
 import '../services/auth.dart';
 import '../sign_in_fab.dart';
+import '../theme.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({Key key, this.title}) : super(key: key);
@@ -20,17 +22,20 @@ class HomePage extends StatefulWidget {
 class _HomePageState extends State<HomePage> {
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(widget.title),
-        centerTitle: true,
-        elevation: 0.0,
-      ),
-      body: PostsList(_loadPosts(context)),
-      floatingActionButton: SignInFab(
-        auth: Auth(
-          firebaseAuth: FirebaseAuth.instance,
-          googleSignIn: GoogleSignIn(),
+    return AnnotatedRegion<SystemUiOverlayStyle>(
+      value: lightSystemUiOverlayStyle,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(widget.title),
+          centerTitle: true,
+          elevation: 0.0,
+        ),
+        body: PostsList(_loadPosts(context)),
+        floatingActionButton: SignInFab(
+          auth: Auth(
+            firebaseAuth: FirebaseAuth.instance,
+            googleSignIn: GoogleSignIn(),
+          ),
         ),
       ),
     );

--- a/app/test/pages/home_page_test.dart
+++ b/app/test/pages/home_page_test.dart
@@ -1,8 +1,11 @@
 import 'package:birb/pages/home_page.dart';
 import 'package:birb/posts_list.dart';
 import 'package:birb/sign_in_fab.dart';
+import 'package:birb/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/rendering.dart';
 
 void main() {
   const MaterialApp app = MaterialApp(
@@ -15,6 +18,11 @@ void main() {
 
     expect(find.text('Awesome'), findsOneWidget);
     expect(find.byType(PostsList), findsOneWidget);
+
+    final AnnotatedRegionLayer<SystemUiOverlayStyle> layer = tester.layers
+        .firstWhere((Layer layer) =>
+            layer is AnnotatedRegionLayer<SystemUiOverlayStyle>);
+    expect(layer.value, lightSystemUiOverlayStyle);
   });
 
   testWidgets('Renders sign in FAB', (WidgetTester tester) async {


### PR DESCRIPTION
**TL;TR**: Prevent Google Sign In to change the `SystemUiOverlayStyle` that causes #51

It seems that the `SystemUiOverlayStyle` applied in `main()` is changed by Google Sign In modal when “Sign in with Google” button is tapped. Then, `home_page.dart` is redrawn and the `AppBar` inherits last used value (Google's dark style, instead of `theme.dart`'s light style). To fix it, `home_page.dart` has to use `theme.dart`'s `SystemUiOverlayStyle`.

From [this Stack Overflow answer](https://stackoverflow.com/a/51944934):
> `AppBar` internally creates an `AnnotatedRegion<SystemUiOverlayStyle>` widget that is processed by Flutter's native UI bindings. It makes the status bar either dark or bright.
> On screens without an `AppBar`, you can use `AnnotatedRegion<SystemUiOverlayStyle>` to set the color of the status bar.

And from [this other](https://stackoverflow.com/a/51013116):
> However if you have multiple widgets which set this value, or use the material `AppBar` or cupertino NavBar your value may be overwritten by them. Instead you could use the new `AnnotatedRegion` API to tell flutter to automatically switch to this style anytime certain widgets are visible.

| **BEFORE** ❌  | **AFTER** ✅  |
|--------|-------|
| <img src="https://user-images.githubusercontent.com/465723/50552726-cff54c80-0c99-11e9-906f-59c192530a3f.gif" width=300 /> | <img src="https://user-images.githubusercontent.com/465723/50552730-16e34200-0c9a-11e9-8eb7-cb8eb3a7edaf.gif" width=300 />  |